### PR TITLE
Forward all issues for Kubeflow org; setup dev environment

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -68,6 +68,7 @@ RUN pip install \
     tensorflow==1.12.0 \
     seldon-core==0.2.6
 
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY flask_app flask_app/

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -5,6 +5,21 @@ with mlbot.net.
 
 This is currently running on a GKE cluster.
 
+See [machine-learning-apps/Issue-Label-Bot#57](https://github.com/machine-learning-apps/Issue-Label-Bot/issues/57) for a log of how
+the service was deployed.
+
+To build a new image
+
+```
+skaffold build
+```
+
+Then to update the image
+
+```
+cd overlays/dev|prod
+kustomize edit set image gcr.io/github-probots/label-bot-frontend=gcr.io/github-probots/label-bot-frontend:${TAG}@${SHA}
+```
 
 ## github-probots
 
@@ -40,11 +55,17 @@ Deploying it
 
 There is a staging cluster for testing running in
 
-* **GCP project**: issue-label-bot-dev
-* **cluster**: github-mlapp-test
-* **namespace**: mlapp
+* **GCP project**: github-probots
+* **cluster**:  kf-ci-ml
+* **namespace**: label-bot-dev
 
 Deploying it
+
+1. Create the secrets
+
+
+
+TODO(jlewi): instructions below are outdated
 
 1. Create the deployment
 

--- a/deployment/base/deployment.yaml
+++ b/deployment/base/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-github-app
+  labels:
+    app: ml-github-app
+spec:
+  replicas: 9
+  selector:
+    matchLabels:
+      app: ml-github-app
+  template:
+    metadata:
+      labels:
+        app: ml-github-app
+    spec:
+      containers:
+      - name: frontend
+        image: gcr.io/github-probots/label-bot-frontend
+        command: ["python", "app.py"]
+        workingDir: "/flask_app"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 3
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: ml-app-inference-secret
+              key: DATABASE_URL
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: ml-app-inference-secret
+              key: WEBHOOK_SECRET
+        # The values for the Kubeflow kf-label-bot-dev application
+        # See kubeflow/code-intelligence#84. This is suitable
+        # for development but shouldn't be used in production       
+        - name: APP_ID
+          value: "50112"
+        # Pato the GitHub app PEM key
+        - name: GITHUB_APP_PEM_KEY
+          value: /var/secrets/github/kf-label-bot-dev.private-key.pem
+        # The GCP project and pubsub topic to publish to.
+        # Default to the test/dev topic
+        - name: GCP_PROJECT_ID
+          value: issue-label-bot-dev
+        - name: GCP_PUBSUB_TOPIC_NAME
+          value: TEST_event_queue
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/google/user-gcp-sa.json        
+        - name: FLASK_ENV
+          value: production
+        - name: PORT
+          value: '3000'
+        - name: APP_URL
+          value: https://mlbot.net/
+        - name: authors
+          value: 'c'
+        ports:
+        - containerPort: 443
+        - containerPort: 80
+        - containerPort: 3000
+        volumeMounts:
+        - name: user-gcp-sa
+          mountPath: /var/secrets/google
+        - name: github-app
+          mountPath: /var/secrets/github
+      volumes:
+      - name: user-gcp-sa
+        secret:
+          secretName: user-gcp-sa
+      - name: github-app
+        secret:
+          secretName: github-app

--- a/deployment/base/ingress.yaml
+++ b/deployment/base/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: frontend  
+  annotations:
+    # The ip and certificate name should be overwritten for each
+    # overlay and set to the correct values
+    kubernetes.io/ingress.global-static-ip-name: fake-ip
+    networking.gke.io/managed-certificates: fake-certificate
+spec:
+  backend:
+    serviceName: ml-github-app
+    servicePort: 3000
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ml-github-app
+          servicePort: 3000

--- a/deployment/base/kustomization.yaml
+++ b/deployment/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: label-bot-
+commonLabels:
+  app: label-bot
+  service: label-bot
+images:
+- name: gcr.io/github-probots/label-bot-frontend
+  newName: gcr.io/github-probots/label-bot-frontend
+resources:
+- deployment.yaml
+- service.yaml
+- ingress.yaml

--- a/deployment/base/service.yaml
+++ b/deployment/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-github-app
+  labels:
+    app: ml-github-app
+spec:
+  ports:
+  - port: 3000
+    protocol: TCP
+  selector:
+    app: ml-github-app
+  type: NodePort

--- a/deployment/overlays/dev/certificate.yaml
+++ b/deployment/overlays/dev/certificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: certificate
+spec:
+  domains:
+    - label-bot-dev.mlbot.net

--- a/deployment/overlays/dev/deployment.yaml
+++ b/deployment/overlays/dev/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-github-app
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: frontend
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: ml-app-inference-secret
+              key: DATABASE_URL
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: ml-app-inference-secret
+              key: WEBHOOK_SECRET        
+        # The values for the Kubeflow kf-label-bot-dev application
+        # See kubeflow/code-intelligence#84. This is suitable
+        # for development but shouldn't be used in production       
+        - name: APP_ID
+          value: "50112"
+        # Path the GitHub app PEM key
+        - name: GITHUB_APP_PEM_KEY
+          value: /var/secrets/github/kf-label-bot-dev.private-key.pem
+        # The GCP project and pubsub topic to publish to should
+        # correspond to the production backend
+        - name: GCP_PROJECT_ID
+          value: issue-label-bot-dev
+        - name: GCP_PUBSUB_TOPIC_NAME
+          value: TEST_event_queue
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/google/user-gcp-sa.json        
+        - name: FLASK_ENV
+          value: production
+  

--- a/deployment/overlays/dev/ingress.yaml
+++ b/deployment/overlays/dev/ingress.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: frontend  
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: label-bot-dev
+    networking.gke.io/managed-certificates: certificate

--- a/deployment/overlays/dev/kustomization.yaml
+++ b/deployment/overlays/dev/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+commonLabels:
+  environment: dev
+namespace: label-bot-dev
+resources:
+- certificate.yaml
+patchesStrategicMerge:
+- deployment.yaml
+- ingress.yaml

--- a/deployment/overlays/prod/deployment.yaml
+++ b/deployment/overlays/prod/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-github-app
+spec:
+  replicas: 9
+    spec:
+      containers:
+      - name: frontend
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: ml-app-inference-secret
+              key: DATABASE_URL
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: ml-app-inference-secret
+              key: WEBHOOK_SECRET
+        # The values for the Kubeflow issue-label-bot application
+        # that is available in the GitHub marketplace      
+        - name: APP_ID
+          value: "27079"
+        # Pato the GitHub app PEM key
+        - name: GITHUB_APP_PEM_KEY
+          value: /var/secrets/github/kf-label-bot-dev.private-key.pem
+        # The GCP project and pubsub topic to publish to should
+        # correspond to the production backend
+        - name: GCP_PROJECT_ID
+          value: issue-label-bot-dev
+        - name: GCP_PUBSUB_TOPIC_NAME
+          value: event_queue
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/google/user-gcp-sa.json        
+        - name: FLASK_ENV
+          value: production
+  

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -1,0 +1,19 @@
+# Developer guide
+
+1. You can deploy the front end using skaffold
+
+   ```
+   skaffold dev --cleanup=False
+   ```
+
+   * Your Kubernetes context should be set to using the `github-probots-dev` namespace
+   * This will continually rebuild and upate your code
+   * Skaffold's file sync feature is used to update the code in the image without rebuilding and
+     redeploying
+   * This makes redeploying very easy.
+
+1. To send a GitHub webhook event you can either open up an issue or you can use `scripts/send_request.py`
+
+   * The latter is useful because it avoids needing to open up a new GitHub issue
+
+     * Right now the bot is only designed to respond to issues opened events.

--- a/flask_app/forward_utils.py
+++ b/flask_app/forward_utils.py
@@ -5,7 +5,7 @@ from google.cloud import pubsub
 def get_forwarded_repos(yaml_path='forwarded_repo.yaml'):
     with open(yaml_path, 'r') as f:
         config = yaml.safe_load(f)
-    return config['repos']
+    return config
 
 def check_topic_path_exists(project_id, topic_path):
     """

--- a/flask_app/forwarded_repo.yaml
+++ b/flask_app/forwarded_repo.yaml
@@ -1,3 +1,4 @@
+orgs:
+    kubeflow: 1.0
 repos:
     abcdefgs0324/issue-label-bot-test: 1.0
-    kubeflow/kubeflow: 0.75

--- a/script/create_secrets.py
+++ b/script/create_secrets.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+"""A script to create the required secrets in one namespace by copying them
+from another namespace
+"""
+
+import base64
+import fire
+from google.cloud import storage
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
+from kubernetes.client import rest
+import logging
+import yaml
+import os
+import re
+import subprocess
+
+# The namespace for the dev environment.
+DEV_NAMESPACE = "label-bot-dev"
+
+GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")
+
+def split_gcs_uri(gcs_uri):
+  """Split a GCS URI into bucket and path."""
+  m = GCS_REGEX.match(gcs_uri)
+  bucket = m.group(1)
+  path = ""
+  if m.group(2):
+    path = m.group(2).lstrip("/")
+  return bucket, path
+
+def secret_exists(namespace, name, client):
+  api = k8s_client.CoreV1Api(client)
+
+  try:
+    api.read_namespaced_secret(name, namespace)
+    return True
+  except rest.ApiException as e:
+    if e.status != 404:
+      raise
+
+  return False
+
+def _read_gcs_path(gcs_path):
+  bucket_name, blob_name = split_gcs_uri(gcs_path)
+
+  storage_client = storage.Client()
+
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(blob_name)
+  contents = blob.download_as_string().decode()
+
+  return contents
+
+class SecretCreator:
+
+  @staticmethod
+  def _secret_from_gcs(secret_name, gcs_path):
+    bucket_name, blob_name = split_gcs_uri(gcs_path)
+
+    storage_client = storage.Client()
+
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    contents = blob.download_as_string().decode()
+
+    file_name = os.path.basename(blob_name)
+    namespace, name = secret_name.split("/", 1)
+    subprocess.check_call(["kubectl", "-n", namespace, "create",
+                           "secret", "generic",
+                           name,
+                           f"--from-literal=f{file_name}={contents}"])
+  @staticmethod
+  def copy_secret(source, dest):
+    """Create the dev version of the secrets.
+
+    Args:
+      source: {namespace}/{secret name}
+      dest: {namespace}/{secret name}
+    """
+    src_namespace, src_name = source.split("/", 1)
+    dest_namespace, dest_name = dest.split("/", 1)
+
+    data = subprocess.check_output(["kubectl", "-n", src_namespace, "get",
+                                    "secrets", src_name, "-o",
+                                    "yaml"])
+
+    encoded = yaml.load(data)
+    decoded = {}
+
+    for k, v in encoded["data"].items():
+      decoded[k] = base64.b64decode(v).decode()
+
+    command = ["kubectl", "create", "-n", dest_namespace, "secret",
+               "generic", dest_name]
+
+    for k, v in decoded.items():
+      command.append(f"--from-literal={k}={v}")
+
+    subprocess.check_call(command)
+
+  @staticmethod
+  def create_dev():
+    """Create the secrets for the dev environment."""
+
+    k8s_config.load_kube_config(persist_config=False)
+
+    client = k8s_client.ApiClient()
+
+    if secret_exists(DEV_NAMESPACE, "user-gcp-sa", client):
+      logging.warning(f"Secret {DEV_NAMESPACE}/user-gcp-sa already exists; "
+                      f"Not recreating it.")
+    else:
+      # We get a GCP secret by copying it from the kubeflow namespace.
+      SecretCreator.copy_secret("kubeflow/user-gcp-sa",
+                                f"{DEV_NAMESPACE}/user-gcp-sa")
+
+    if secret_exists(DEV_NAMESPACE, "github-app", client):
+      logging.warning(f"Secret {DEV_NAMESPACE}/github-app already exists; "
+                      f"Not recreating it.")
+    else:
+      # Create the secret containing the PEM key for the github app
+      SecretCreator._secret_from_gcs(f"{DEV_NAMESPACE}/github-app",
+                                     "gs://issue-label-bot-dev_secrets/kf-label-bot-dev.2019-12-30.private-key.pem")
+
+    # Create the inference secret containing the postgres database with
+    # postgres secret and the webhook secret
+    inference_secret = "ml-app-inference-secret"
+    if secret_exists(DEV_NAMESPACE, inference_secret, client):
+      logging.warning(f"Secret {DEV_NAMESPACE}/{inference_secret} already exists; "
+                      f"Not recreating it.")
+    else:
+      postgres = _read_gcs_path("gs://issue-label-bot-dev_secrets/"
+                                "issue-label-bot.postgres")
+      webhook = _read_gcs_path("gs://issue-label-bot-dev_secrets/"
+                                "kf-label-bot-dev.webhook.secret")
+
+      subprocess.check_call(["kubectl", "-n", DEV_NAMESPACE, "create",
+                             "secret", "generic",
+                             inference_secret,
+                             f"--from-literal=DATABASE_URL={postgres}",
+                             f"--from-literal=WEBHOOK_SECRET={webhook}"])
+
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(message)s|%(pathname)s|%(lineno)d|'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+
+  fire.Fire(SecretCreator)

--- a/script/send_request.py
+++ b/script/send_request.py
@@ -1,0 +1,62 @@
+"""A helper script to send requests to test the label bot."""
+import base64
+import fire
+import hmac
+import json
+import logging
+import requests
+import subprocess
+
+class SendRequest:
+  @staticmethod
+  def send(url="https://label-bot-dev.mlbot.net/event_handler"):
+    # Get the webhook secret
+    secret = subprocess.check_output(["kubectl", "get", "secret",
+                                      "ml-app-inference-secret",
+                                      "-o", "jsonpath='{.data.WEBHOOK_SECRET}'"])
+
+    secret_decoded = base64.b64decode(secret).decode()
+
+    # TODO(jlewi): We should allow specificing a specific issue.
+    payload = {
+      "action": "opened",
+      # Installation corresponding to kf-label-bot-dev on
+      # kubeflow/code-intelligence
+      "installation": {
+        "id": 5980888,
+      },
+      "issue": {
+        "number": 99,
+        "title": "Test kf-label bot-dev this is a bug",
+        "body": ("Test whether events are correctly routed to the dev instance."
+                 "If not then there is a bug in the setup")
+      },
+      "repository": {
+        "full_name": "kubeflow/code-intelligence",
+        "private": False,
+      }
+    }
+
+    data = str.encode(json.dumps(payload))
+    # See: https://developer.github.com/webhooks/securing/
+    # We need to compute the signature of the payload using the secret
+    mac = hmac.new(str.encode(secret_decoded), msg=data, digestmod='sha1')
+
+    headers = {
+     "X-Hub-Signature": "=" + mac.hexdigest(),
+     "Content-Type": "application/json",
+    }
+
+    # We use data and not json because we need to compute the hash of the
+    # data to match the signature
+    requests.post(url, data=data, headers=headers)
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(message)s|%(pathname)s|%(lineno)d|'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+
+  fire.Fire(SendRequest)
+

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,40 @@
+# Reference: https://skaffold.dev/docs/references/yaml/
+apiVersion: skaffold/v2alpha1
+kind: Config
+metadata:
+  name: label-bot
+build:
+  artifacts:
+  - image: gcr.io/github-probots/label-bot-frontend
+    # Set the context to the root directory. 
+    # All paths in the Dockerfile should be relative to this one.
+    context: .
+    # TODO(https://github.com/GoogleContainerTools/skaffold/issues/3448): We use manual sync
+    # because inferred sync doesn't work
+    sync:
+      manual:
+      - src: 'flask_app/*.py'
+        dest: '/'    
+    kaniko:
+      dockerfile: deployment/Dockerfile
+      buildContext:
+        gcsBucket: github-probots_skaffold
+      env: 
+        # TODO(GoogleContainerTools/skaffold#3468) skaffold doesn't
+        # appear to work with workload identity
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secret/user-gcp-sa.json
+      cache: {}
+  cluster:    
+    pullSecretName: user-gcp-sa
+    # Build in the kaniko namespace because we need to disable ISTIO sidecar injection
+    # see  GoogleContainerTools/skaffold#3442
+    namespace: label-bot-dev
+    resources:
+      requests:
+        cpu: 8
+        memory: 16Gi
+
+deploy:
+  kustomize:
+    path: deployment/overlays/dev


### PR DESCRIPTION
* #57 is tracking setting up new staging and prod environments

  * This PR sets up a new staging (or dev environment)
  * We create a kustomize manifest for deploying the front end into that
    namespace
  * The staging environment is configured to use the dev instance of the
    issue label bot backend microservice (i.e the pubsub workers)
  * I created some python scripts to make it easier to setup the secrets.
  * The motivation for doing this was to test the changes to the front end

* Front end now forwards all issues for the kubeflow org to the backend

  * This is needed because we want to use multiple models for all Kubeflow
    repos kubeflow/code-intelligence#70

  * The backend should also be configured with logging to measure the impact
    of the predictions.

kubeflow/code-intelligence#104 is an a test issue showing that the bot is
working.

* Fix how keys are handled

  * For GOOGLE_APPLICATION_CREDENTIALS; depend on that environment variable
    being set and pointing to the file containing the private key;
    don't get the private key from an environment variable and then write it
    to a file.

* For the GitHub App private key; use an environment variable to point to
  the file containing the PEM key.

* Create a script to create the secrets.

* Flask app is running in dev namespace

  * create_secrets.py creates secrets needed for dev instance