### PR TITLE
Let the label bot respond to additional comments; not just when an issue is created

### DIFF
--- a/.build/prod/apps_v1_deployment_label-bot-ml-github-app.yaml
+++ b/.build/prod/apps_v1_deployment_label-bot-ml-github-app.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: label-bot
+    environment: prod
+    service: label-bot
+  name: label-bot-ml-github-app
+  namespace: label-bot-prod
+spec:
+  replicas: 9
+  selector:
+    matchLabels:
+      app: label-bot
+      environment: prod
+      service: label-bot
+  template:
+    metadata:
+      labels:
+        app: label-bot
+        environment: prod
+        service: label-bot
+    spec:
+      containers:
+      - command:
+        - python
+        - app.py
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              key: DATABASE_URL
+              name: ml-app-inference-secret
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: WEBHOOK_SECRET
+              name: ml-app-inference-secret
+        - name: APP_ID
+          value: "27079"
+        - name: GITHUB_APP_PEM_KEY
+          value: /var/secrets/github/kf-label-bot-prod.private-key.pem
+        - name: GCP_PROJECT_ID
+          value: issue-label-bot-dev
+        - name: GCP_PUBSUB_TOPIC_NAME
+          value: event_queue
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/secrets/google/user-gcp-sa.json
+        - name: FLASK_ENV
+          value: production
+        - name: PORT
+          value: "3000"
+        - name: APP_URL
+          value: https://mlbot.net/
+        - name: authors
+          value: c
+        image: gcr.io/github-probots/label-bot-frontend:3f698dc
+        name: frontend
+        ports:
+        - containerPort: 443
+        - containerPort: 80
+        - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 3
+        volumeMounts:
+        - mountPath: /var/secrets/google
+          name: user-gcp-sa
+        - mountPath: /var/secrets/github
+          name: github-app
+        workingDir: /flask_app
+      volumes:
+      - name: user-gcp-sa
+        secret:
+          secretName: user-gcp-sa
+      - name: github-app
+        secret:
+          secretName: github-app

--- a/.build/prod/extensions_v1beta1_ingress_label-bot-frontend.yaml
+++ b/.build/prod/extensions_v1beta1_ingress_label-bot-frontend.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: label-bot-prod
+    networking.gke.io/managed-certificates: certificate
+  labels:
+    app: label-bot
+    environment: prod
+    service: label-bot
+  name: label-bot-frontend
+  namespace: label-bot-prod
+spec:
+  backend:
+    serviceName: label-bot-ml-github-app
+    servicePort: 3000
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: label-bot-ml-github-app
+          servicePort: 3000
+        path: /

--- a/.build/prod/networking.gke.io_v1beta1_managedcertificate_certificate.yaml
+++ b/.build/prod/networking.gke.io_v1beta1_managedcertificate_certificate.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  labels:
+    environment: prod
+  name: certificate
+  namespace: label-bot-prod
+spec:
+  domains:
+  - label-bot-prod.mlbot.net

--- a/.build/prod/~g_v1_service_label-bot-ml-github-app.yaml
+++ b/.build/prod/~g_v1_service_label-bot-ml-github-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: label-bot
+    environment: prod
+    service: label-bot
+  name: label-bot-ml-github-app
+  namespace: label-bot-prod
+spec:
+  ports:
+  - port: 3000
+    protocol: TCP
+  selector:
+    app: label-bot
+    environment: prod
+    service: label-bot
+  type: NodePort

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+!.build
 .*
 *.pem
 *.hdf5

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,16 @@ else
 GIT_VERSION := $(shell git describe --always)-dirty-$(shell git diff | shasum -a256 | cut -c -6)
 endif
 
+CONTEXT=label-bot-frontend-prod
+
+hydrate-prod:
+	rm -rf .build/prod
+	mkdir -p .build/prod
+	kustomize build -o .build/prod deployment/overlays/prod
+
+apply-prod: hydrate-prod
+	kubectl --context=$(CONTEXT) apply -f .build/prod
+
 TAG := $(shell date +v%Y%m%d)-$(GIT_VERSION)
 all: build
 

--- a/deployment/overlays/prod/kustomization.yaml
+++ b/deployment/overlays/prod/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: label-bot-prod
 images:
 - name: gcr.io/github-probots/label-bot-frontend
   newName: gcr.io/github-probots/label-bot-frontend
-  newTag: 2cb624e
+  newTag: 3f698dc
 resources:
 - certificate.yaml
 - ../../base

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -123,7 +123,7 @@ def bot():
     verify_webhook(request)
 
     # Check if payload corresponds to an issue being opened
-    if 'action' not in request.json or request.json['action'] != 'opened' or 'issue' not in request.json:
+    if 'issue' not in request.json:
         logging.warning("Event is not for an issue with action opened.")
         return 'ok'
 
@@ -143,6 +143,9 @@ def bot():
     logging.info(f"Recieved {username}/{repo}#{issue_num}")
     try:
         # forward some issues of specific repos and select by their given forwarded proportion
+        # TODO(jlewi): We could probably simplify this because at this point
+        # for any repo/org that we are forwarding the issues we should probably
+        # always forward the issues.
         forward_probability = None
         repo_spec = f'{username}/{repo}'
         if username in forwarded_repos.get("orgs", {}):
@@ -166,6 +169,11 @@ def bot():
         logging.error(f"Exception occured while handling issue "
                       f"{username}/{repo}#{issue_num}\n Exception: {e}\n"
                       f"{traceback.format_exc()}")
+
+    # Check if payload corresponds to an issue being opened
+    if 'action' not in request.json or request.json['action'] != 'opened':
+        logging.warning("Event is not for an issue with action opened.")
+        return 'ok'
 
     # write the issue to the database using ORM
     issue_db_obj = Issues(repo=repo,


### PR DESCRIPTION
…sue is opened.

* See kubeflow/code-intelligence#133 we want to allow the label bot
  to respond after additional comments on an issue and take those comments
  into account. This is because additional comments on the issue
  might provide more data pointing at how the issue should be labeled.

* We only do this for issues that are forwarded to a pubsub backend and
  using the newer code for label prediction.

related to kubeflow/code-intelligence#133